### PR TITLE
Update String action to handle empty strings

### DIFF
--- a/jparse/json_actions.py
+++ b/jparse/json_actions.py
@@ -22,7 +22,8 @@ def object_action(context, nodes):
 
 @action("String")
 def string_action(context, nodes):
-    return pass_inner(context, nodes)
+    str = pass_inner(context, nodes)
+    return str if str else ""
 
 
 # Terminal Rule actions


### PR DESCRIPTION
The String action was previously using only `pass_inner`, but that
built-in action returns an empty list when the node has a length of < 3.
Updated the action to properly return an empty string.